### PR TITLE
fix(use-copy-clipboard): add timer cleanup

### DIFF
--- a/frontend/hooks/use-copy-clipboard.ts
+++ b/frontend/hooks/use-copy-clipboard.ts
@@ -4,9 +4,11 @@ function useCopyToClipboard() {
     const [hasCopied, setHasCopied] = useState(false);
 
     useEffect(() => {
-        setTimeout(() => {
+        const id = setTimeout(() => {
             setHasCopied(false);
         }, 2000);
+
+        return () => clearTimeout(id);
     }, [hasCopied]);
 
     const copyToClipboard = (text: string) => {


### PR DESCRIPTION
# Pull Request for Memfree

## Description

The `use-copy-clipboard` hook does not provide a cleanup function for `setTimeout` which can cause weird issues. This PR addresses that and correctly cleans up the timer.

## Related Issue

N/A

## Changes Made

- [ ] Added new feature
- [x] Fixed a bug
- [ ] Updated documentation
- [ ] Other (please specify)


## Checklist

- [x] I have read the contributing guidelines
- [x] I have followed the code style guidelines
- [x] My code is tested and works as expected
- [ ] I have updated the documentation (if necessary)

## Additional Information

Please provide any additional information that may be helpful for the reviewers.
