### PR TITLE
refactor(server-utils): use builtin abort signal timeout

### DIFF
--- a/frontend/lib/server-utils.ts
+++ b/frontend/lib/server-utils.ts
@@ -11,17 +11,11 @@ interface FetchWithTimeoutOptions extends RequestInit {
 export const fetchWithTimeout = async (resource: RequestInfo, options: FetchWithTimeoutOptions = {}): Promise<Response> => {
     const { timeout = 10000 } = options;
 
-    const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), timeout);
-    try {
-        const response = await fetch(resource, {
-            ...options,
-            signal: controller.signal,
-        });
-        return response;
-    } finally {
-        clearTimeout(id);
-    }
+    const response = await fetch(resource, {
+        ...options,
+        signal: AbortSignal.timeout(timeout),
+    });
+    return response;
 };
 
 export function extractYouTubeId(url: string): string {


### PR DESCRIPTION
# Pull Request for Memfree

## Description

This PR replaces custom abort signal timeout with [built in abort signal timeout](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static).

#### From
```ts
const controller = new AbortController();
const id = setTimeout(() => controller.abort(), timeout);

signal: controller.signal
```

#### To
```ts
signal: AbortSignal.timeout(timeout)
```

## Changes Made

- [ ] Added new feature
- [ ] Fixed a bug
- [ ] Updated documentation
- [x] Other (Refactored)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have followed the code style guidelines
- [x] My code is tested and works as expected
- [ ] I have updated the documentation (if necessary)

## Additional Information

Please provide any additional information that may be helpful for the reviewers.
