### PR TITLE
fix(shared-utils): return early if the url cannot be parsed

### DIFF
--- a/frontend/lib/shared-utils.ts
+++ b/frontend/lib/shared-utils.ts
@@ -1,6 +1,9 @@
 // The utility functions in this file are shared between the client and the server.
 
 export function isValidUrl(input: string): boolean {
+    // return early if the url cannot be parsed
+    if ('canParse' in URL && !URL.canParse(input)) return false;
+    
     try {
         const url = new URL(input);
         if (url.protocol !== 'http:' && url.protocol !== 'https:') {


### PR DESCRIPTION
# Pull Request for Memfree

## Description

This PR updates url validation function to return early if the url cannot be parsed. This uses the native `canParse` method if supported, which validates the input without constructing the url object which can be expensive.

## Changes Made

- [ ] Added new feature
- [ ] Fixed a bug
- [ ] Updated documentation
- [x] Other (refactored)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have followed the code style guidelines
- [x] My code is tested and works as expected
- [ ] I have updated the documentation (if necessary)

## Additional Information

Please provide any additional information that may be helpful for the reviewers.
