### PR TITLE
Fix: Correct typo in formatBytes function for size unit 'Bytest'

### DIFF
--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -71,7 +71,7 @@ export function formatBytes(
     const accurateSizes = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB'];
     if (bytes === 0) return '0 Byte';
     const i = Math.floor(Math.log(bytes) / Math.log(1024));
-    return `${(bytes / Math.pow(1024, i)).toFixed(decimals)} ${sizeType === 'accurate' ? accurateSizes[i] ?? 'Bytest' : sizes[i] ?? 'Bytes'}`;
+    return `${(bytes / Math.pow(1024, i)).toFixed(decimals)} ${(sizeType === 'accurate' ? accurateSizes[i] : sizes[i]) ?? 'Bytes'}`;
 }
 
 export function getFileSizeLimit(user: any) {


### PR DESCRIPTION
# Fix typo in size unit in formatBytes function

## Description

Corrected typo 'Bytest' to 'Bytes' in formatBytes function for accurate size output.

## Changes Made

- [ ] Added new feature
- [X] Fixed a bug
- [ ] Updated documentation
- [ ] Other (please specify)


## Checklist

- [X] I have read the contributing guidelines
- [X] I have followed the code style guidelines
- [X] My code is tested and works as expected
- [ ] I have updated the documentation (if necessary)

