### PR TITLE
fix: #111 - scrollbar showing in center for pricing page

### DIFF
--- a/frontend/app/[locale]/(search)/pricing/page.tsx
+++ b/frontend/app/[locale]/(search)/pricing/page.tsx
@@ -27,7 +27,7 @@ export default async function PricingPage() {
     }
 
     return (
-        <div className="group mx-auto overflow-auto peer-[[data-state=open]]:lg:pl-[300px] peer-[[data-state=open]]:xl:pl-[320px] peer-[[data-state=closed]]:lg:pl-[100px] my-10">
+        <div className="group mx-auto overflow-auto peer-[[data-state=open]]:lg:pl-[300px] peer-[[data-state=open]]:xl:pl-[320px] peer-[[data-state=closed]]:lg:px-[100px] my-10">
             <PricingCards userId={user?.id} subscriptionPlan={subscriptionPlan} />
             <WallOfLove />
             <PricingFaq />

--- a/frontend/components/pricing-cards.tsx
+++ b/frontend/components/pricing-cards.tsx
@@ -173,7 +173,7 @@ export function PricingCards({ userId, subscriptionPlan }: PricingCardsProps) {
                 </ToggleGroup>
             </div>
 
-            <div className="mx-auto grid max-w-6xl gap-5 bg-inherit py-5 md:grid-cols-3 lg:grid-cols-3">
+            <div className="mx-auto grid gap-5 bg-inherit py-5 md:grid-cols-3 lg:grid-cols-3">
                 {pricingData.map((offer) => (
                     <PricingCard offer={offer} key={offer.title} />
                 ))}


### PR DESCRIPTION
# Pull Request for Memfree

## Description

- Removed one separate class which was used to center the pricing div
- Add equal padding on both side of the page


## Related Issue

If this pull request addresses an issue, please link to it here. For example:
- Closes #111 Scrollbar in center of the screen


## Changes Made

- [ ] Added new feature
- [x] Fixed a bug
- [ ] Updated documentation
- [ ] Other (please specify)

## How to Test

Please describe the steps to test the changes made in this pull request. Include any specific commands or configurations needed.

1. Goto - https://www.memfree.me/pricing
2. Here the sidebar shows between screens. 

## Screenshots (if applicable)

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/142c8cf8-8b15-493b-9ebd-eed76226b97a">


## Checklist

- [x] I have read the contributing guidelines
- [x] I have followed the code style guidelines
- [x] My code is tested and works as expected
- [x] I have updated the documentation (if necessary)

## Additional Information

Please provide any additional information that may be helpful for the reviewers.
