### PR TITLE
fix: correct falied->failed typo in clipboard copy error message

### DIFF
--- a/frontend/hooks/use-copy-clipboard.ts
+++ b/frontend/hooks/use-copy-clipboard.ts
@@ -15,7 +15,7 @@ function useCopyToClipboard() {
         navigator.clipboard
             .writeText(text)
             .then(() => setHasCopied(true))
-            .catch((error) => console.error('Copy falied:', error));
+            .catch((error) => console.error('Copy failed:', error));
     };
 
     return { hasCopied, copyToClipboard };


### PR DESCRIPTION
Fix user-facing console.error message typo in frontend/hooks/use-copy-clipboard.ts.

**Before:** console.error('Copy falied:', error);
**After:** console.error('Copy failed:', error);

Co-authored-by: Jah-yee <jydu_seven@outlook.com>